### PR TITLE
 Support OCI registry creds with environment variables

### DIFF
--- a/internal/app/wwctl/container/imprt/main.go
+++ b/internal/app/wwctl/container/imprt/main.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strconv"
 
+	"github.com/containers/image/v5/types"
 	"github.com/hpcng/warewulf/internal/pkg/container"
 	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/hpcng/warewulf/internal/pkg/util"
@@ -12,6 +14,56 @@ import (
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 	"github.com/spf13/cobra"
 )
+
+func setOCICredentials(sCtx *types.SystemContext) error {
+	username, userSet := os.LookupEnv("WAREWULF_OCI_USERNAME")
+	password, passSet := os.LookupEnv("WAREWULF_OCI_PASSWORD")
+	if userSet || passSet {
+		if userSet && passSet {
+			sCtx.DockerAuthConfig = &types.DockerAuthConfig{
+				Username: username,
+				Password: password,
+			}
+		} else {
+			return fmt.Errorf("oci username and password env vars must be specified together")
+		}
+	}
+	return nil
+}
+
+func setNoHTTPSOpts(sCtx *types.SystemContext) error {
+	val, ok := os.LookupEnv("WAREWULF_OCI_NOHTTPS")
+	if !ok {
+		return nil
+	}
+
+	noHTTPS, err := strconv.ParseBool(val)
+	if err != nil {
+		return fmt.Errorf("while parsing insecure http option: %v", err)
+	}
+
+	// only set this if we want to disable, otherwise leave as undefined
+	if noHTTPS {
+		sCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(true)
+	}
+	sCtx.OCIInsecureSkipTLSVerify = noHTTPS
+
+	return nil
+}
+
+func getSystemContext() (sCtx *types.SystemContext, err error) {
+	sCtx = &types.SystemContext{}
+
+	if err := setOCICredentials(sCtx); err != nil {
+		return nil, err
+	}
+
+	if err := setNoHTTPSOpts(sCtx); err != nil {
+		return nil, err
+	}
+
+	return sCtx, nil
+}
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
 	var name string
@@ -47,7 +99,12 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	err := container.PullURI(uri, name)
+	sCtx, err := getSystemContext()
+	if err != nil {
+		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+	}
+
+	err = container.PullURI(uri, name, sCtx)
 	if err != nil {
 		wwlog.Printf(wwlog.ERROR, "Could not pull image: %s\n", err)
 		os.Exit(1)

--- a/internal/pkg/container/pull.go
+++ b/internal/pkg/container/pull.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"os"
 
+	"github.com/containers/image/v5/types"
 	"github.com/hpcng/warewulf/internal/pkg/config"
 	"github.com/hpcng/warewulf/internal/pkg/errors"
 	"github.com/hpcng/warewulf/internal/pkg/oci"
 )
 
-func PullURI(uri string, name string) error {
+func PullURI(uri string, name string, sCtx *types.SystemContext) error {
 	OciBlobCacheDir := config.LocalStateDir + "/oci/blobs"
 
 	err := os.MkdirAll(OciBlobCacheDir, 0755)
@@ -30,13 +31,15 @@ func PullURI(uri string, name string) error {
 
 	p, err := oci.NewPuller(
 		oci.OptSetBlobCachePath(OciBlobCacheDir),
-		oci.OptSetSystemContext(nil),
+		oci.OptSetSystemContext(sCtx),
 	)
 	if err != nil {
 		return err
 	}
 
-	p.GenerateID(context.Background(), uri)
+	if _, err := p.GenerateID(context.Background(), uri); err != nil {
+		return err
+	}
 
 	if err := p.Pull(context.Background(), uri, fullPath); err != nil {
 		return err

--- a/internal/pkg/oci/puller.go
+++ b/internal/pkg/oci/puller.go
@@ -100,7 +100,7 @@ func (p *puller) GenerateID(ctx context.Context, uri string) (string, error) {
 		return "", fmt.Errorf("unable to parse uri: %v", err)
 	}
 
-	src, err := ref.NewImageSource(ctx, nil)
+	src, err := ref.NewImageSource(ctx, p.sysCtx)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Adds support to 3 environment variables:
- WAREWULF_OCI_USERNAME: registry user username
- WAREWULF_OCI_PASSWORD: registry user password
- WAREWULF_OCI_NOHTTPS: disable tls requirements (for local registries)
    
Note:
        This will default to ~/.docker/config.json for credentials and other docke configurations on the system when no options are specified.

Note^2: this should be merged after #26
